### PR TITLE
Minimum/Maximum の値をAttributeの型に合わせるように修正する案

### DIFF
--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -467,26 +467,59 @@ func Minimum(val interface{}) {
 	if a, ok := attributeDefinition(); ok {
 		if a.Type != nil && a.Type.Kind() != design.IntegerKind && a.Type.Kind() != design.NumberKind {
 			incompatibleAttributeType("minimum", a.Type.Name(), "an integer or a number")
-		} else {
-			var f float64
-			switch v := val.(type) {
-			case float32, float64, int, int8, int16, int32, int64, uint8, uint16, uint32, uint64:
-				f = reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
-			case string:
-				var err error
-				f, err = strconv.ParseFloat(v, 64)
+			return
+		}
+		if a.Validation == nil {
+			a.Validation = &dslengine.ValidationDefinition{}
+		}
+		switch v := val.(type) {
+		case int, int8, int16, int32, int64, uint8, uint16, uint32, uint64:
+			if a.Type.Kind() == design.IntegerKind {
+				min := reflect.ValueOf(v).Convert(reflect.TypeOf(int64(0))).Int()
+				if a.Validation.Minimum == nil || reflect.ValueOf(a.Validation.Minimum).Int() > min {
+					a.Validation.Minimum = int(min)
+				}
+			} else if a.Type.Kind() == design.NumberKind {
+				min := reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
+				if a.Validation.Minimum == nil || reflect.ValueOf(a.Validation.Minimum).Float() > min {
+					a.Validation.Minimum = min
+				}
+			} else {
+				dslengine.ReportError("invalid number value %#v", v)
+				return
+			}
+		case float32, float64:
+			if a.Type.Kind() != design.NumberKind {
+				dslengine.ReportError("incompatible with attribute of type, %#v", v)
+				return
+			}
+			a.Validation.Minimum = reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
+		case string:
+			if a.Type.Kind() == design.IntegerKind {
+				min, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					dslengine.ReportError("invalid number value %#v", v)
 					return
 				}
-			default:
+				if a.Validation.Minimum == nil || reflect.ValueOf(a.Validation.Minimum).Int() > min {
+					a.Validation.Minimum = int(min)
+				}
+			} else if a.Type.Kind() == design.NumberKind {
+				min, err := strconv.ParseFloat(v, 64)
+				if err != nil {
+					dslengine.ReportError("invalid number value %#v", v)
+					return
+				}
+				if a.Validation.Minimum == nil || reflect.ValueOf(a.Validation.Minimum).Float() > min {
+					a.Validation.Minimum = min
+				}
+			} else {
 				dslengine.ReportError("invalid number value %#v", v)
 				return
 			}
-			if a.Validation == nil {
-				a.Validation = &dslengine.ValidationDefinition{}
-			}
-			a.Validation.Minimum = &f
+		default:
+			dslengine.ReportError("invalid number value %#v", v)
+			return
 		}
 	}
 }
@@ -499,26 +532,59 @@ func Maximum(val interface{}) {
 	if a, ok := attributeDefinition(); ok {
 		if a.Type != nil && a.Type.Kind() != design.IntegerKind && a.Type.Kind() != design.NumberKind {
 			incompatibleAttributeType("maximum", a.Type.Name(), "an integer or a number")
-		} else {
-			var f float64
-			switch v := val.(type) {
-			case float32, float64, int, int8, int16, int32, int64, uint8, uint16, uint32, uint64:
-				f = reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
-			case string:
-				var err error
-				f, err = strconv.ParseFloat(v, 64)
+			return
+		}
+		if a.Validation == nil {
+			a.Validation = &dslengine.ValidationDefinition{}
+		}
+		switch v := val.(type) {
+		case int, int8, int16, int32, int64, uint8, uint16, uint32, uint64:
+			if a.Type.Kind() == design.IntegerKind {
+				max := reflect.ValueOf(v).Convert(reflect.TypeOf(int64(0))).Int()
+				if a.Validation.Maximum == nil || reflect.ValueOf(a.Validation.Maximum).Int() < max {
+					a.Validation.Maximum = int(max)
+				}
+			} else if a.Type.Kind() == design.NumberKind {
+				max := reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
+				if a.Validation.Maximum == nil || reflect.ValueOf(a.Validation.Maximum).Float() < max {
+					a.Validation.Maximum = max
+				}
+			} else {
+				dslengine.ReportError("invalid number value %#v", v)
+				return
+			}
+		case float32, float64:
+			if a.Type.Kind() != design.NumberKind {
+				dslengine.ReportError("incompatible with attribute of type, %#v", v)
+				return
+			}
+			a.Validation.Maximum = reflect.ValueOf(v).Convert(reflect.TypeOf(float64(0.0))).Float()
+		case string:
+			if a.Type.Kind() == design.IntegerKind {
+				max, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					dslengine.ReportError("invalid number value %#v", v)
 					return
 				}
-			default:
+				if a.Validation.Maximum == nil || reflect.ValueOf(a.Validation.Maximum).Int() < max {
+					a.Validation.Maximum = int(max)
+				}
+			} else if a.Type.Kind() == design.NumberKind {
+				max, err := strconv.ParseFloat(v, 64)
+				if err != nil {
+					dslengine.ReportError("invalid number value %#v", v)
+					return
+				}
+				if a.Validation.Maximum == nil || reflect.ValueOf(a.Validation.Maximum).Float() < max {
+					a.Validation.Maximum = max
+				}
+			} else {
 				dslengine.ReportError("invalid number value %#v", v)
 				return
 			}
-			if a.Validation == nil {
-				a.Validation = &dslengine.ValidationDefinition{}
-			}
-			a.Validation.Maximum = &f
+		default:
+			dslengine.ReportError("invalid number value %#v", v)
+			return
 		}
 	}
 }

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -82,27 +82,27 @@ type (
 	// ContactDefinition contains the API contact information.
 	ContactDefinition struct {
 		// Name of the contact person/organization
-		Name string `json:"name,omitempty"`
+		Name string `json:"name,omitempty" yaml:"name,omitempty"`
 		// Email address of the contact person/organization
-		Email string `json:"email,omitempty"`
+		Email string `json:"email,omitempty" yaml:"email,omitempty"`
 		// URL pointing to the contact information
-		URL string `json:"url,omitempty"`
+		URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	}
 
 	// LicenseDefinition contains the license information for the API.
 	LicenseDefinition struct {
 		// Name of license used for the API
-		Name string `json:"name,omitempty"`
+		Name string `json:"name,omitempty" yaml:"name,omitempty"`
 		// URL to the license used for the API
-		URL string `json:"url,omitempty"`
+		URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	}
 
 	// DocsDefinition points to external documentation.
 	DocsDefinition struct {
 		// Description of documentation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// URL to documentation.
-		URL string `json:"url,omitempty"`
+		URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	}
 
 	// ResourceDefinition describes a REST resource.

--- a/design/security.go
+++ b/design/security.go
@@ -30,7 +30,7 @@ type SecurityDefinition struct {
 	Scheme *SecuritySchemeDefinition
 
 	// Scopes are scopes required for this action
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 }
 
 // Context returns the generic definition name used in error messages.
@@ -48,27 +48,27 @@ type SecuritySchemeDefinition struct {
 
 	// Scheme is the name of the security scheme, referenced in
 	// Security() declarations. Ex: "googAuth", "my_big_token", "jwt".
-	SchemeName string `json:"scheme"`
+	SchemeName string `json:"scheme" yaml:"scheme"`
 
 	// Type is one of "apiKey", "oauth2" or "basic", according to the
 	// Swagger specs. We also support "jwt".
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 	// Description describes the security scheme. Ex: "Google OAuth2"
-	Description string `json:"description"`
+	Description string `json:"description" yaml:"description"`
 	// In determines whether it is in the "header" or in the "query"
 	// string that we will find an `apiKey`.
-	In string `json:"in,omitempty"`
+	In string `json:"in,omitempty" yaml:"in,omitempty"`
 	// Name refers to a header or parameter name, based on In's value.
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Scopes is a list of available scopes for this scheme, along
 	// with their textual description.
-	Scopes map[string]string `json:"scopes,omitempty"`
+	Scopes map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 	// Flow determines the oauth2 flow to use for this scheme.
-	Flow string `json:"flow,omitempty"`
+	Flow string `json:"flow,omitempty" yaml:"flow,omitempty"`
 	// TokenURL holds the URL for refreshing tokens with oauth2 or JWT
-	TokenURL string `json:"token_url,omitempty"`
+	TokenURL string `json:"token_url,omitempty" yaml:"token_url,omitempty"`
 	// AuthorizationURL holds URL for retrieving authorization codes with oauth2
-	AuthorizationURL string `json:"authorization_url,omitempty"`
+	AuthorizationURL string `json:"authorization_url,omitempty" yaml:"authorization_url,omitempty"`
 	// Metadata is a list of key/value pairs
 	Metadata dslengine.MetadataDefinition
 }

--- a/design/validation_test.go
+++ b/design/validation_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Validation", func() {
 			It("records the validation", func() {
 				Ω(dslengine.Errors).ShouldNot(HaveOccurred())
 				Ω(att.Validation).ShouldNot(BeNil())
-				Ω(*att.Validation.Minimum).Should(Equal(2.0))
+				Ω(att.Validation.Minimum).Should(Equal(2))
 			})
 		})
 
@@ -199,7 +199,7 @@ var _ = Describe("Validation", func() {
 			It("records the validation", func() {
 				Ω(dslengine.Errors).ShouldNot(HaveOccurred())
 				Ω(att.Validation).ShouldNot(BeNil())
-				Ω(*att.Validation.Maximum).Should(Equal(2.0))
+				Ω(att.Validation.Maximum).Should(Equal(2))
 			})
 		})
 

--- a/dslengine/validation_test.go
+++ b/dslengine/validation_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Validation", func() {
 				Ω(dslengine.Errors).ShouldNot(HaveOccurred())
 				Ω(att.Validation).ShouldNot(BeNil())
 				Ω(att.Validation.Minimum).ShouldNot(BeNil())
-				Ω(*att.Validation.Minimum).Should(Equal(float64(2)))
+				Ω(att.Validation.Minimum).Should(Equal(2))
 			})
 		})
 
@@ -180,7 +180,7 @@ var _ = Describe("Validation", func() {
 				Ω(dslengine.Errors).ShouldNot(HaveOccurred())
 				Ω(att.Validation).ShouldNot(BeNil())
 				Ω(att.Validation.Maximum).ShouldNot(BeNil())
-				Ω(*att.Validation.Maximum).Should(Equal(float64(2)))
+				Ω(att.Validation.Maximum).Should(Equal(2))
 			})
 		})
 

--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"text/template"
 
@@ -375,9 +374,9 @@ func validationsCode(att *design.AttributeDefinition, data map[string]interface{
 	}
 	if min := validation.Minimum; min != nil {
 		if att.Type == design.Integer {
-			data["min"] = renderInteger(*min)
+			data["min"] = fmt.Sprintf("%d", min)
 		} else {
-			data["min"] = fmt.Sprintf("%f", *min)
+			data["min"] = fmt.Sprintf("%f", min)
 		}
 		data["isMin"] = true
 		delete(data, "max")
@@ -387,9 +386,9 @@ func validationsCode(att *design.AttributeDefinition, data map[string]interface{
 	}
 	if max := validation.Maximum; max != nil {
 		if att.Type == design.Integer {
-			data["max"] = renderInteger(*max)
+			data["max"] = fmt.Sprintf("%d", max)
 		} else {
-			data["max"] = fmt.Sprintf("%f", *max)
+			data["max"] = fmt.Sprintf("%f", max)
 		}
 		data["isMin"] = false
 		delete(data, "min")
@@ -425,18 +424,6 @@ func validationsCode(att *design.AttributeDefinition, data map[string]interface{
 		res = append(res, val)
 	}
 	return
-}
-
-// renderInteger renders a max or min value properly, taking into account
-// overflows due to casting from a float value.
-func renderInteger(f float64) string {
-	if f > math.Nextafter(float64(math.MaxInt64), 0) {
-		return fmt.Sprintf("%d", int64(math.MaxInt64))
-	}
-	if f < math.Nextafter(float64(math.MinInt64), 0) {
-		return fmt.Sprintf("%d", int64(math.MinInt64))
-	}
-	return fmt.Sprintf("%d", int64(f))
 }
 
 // oneof produces code that compares target with each element of vals and ORs

--- a/goagen/codegen/validation_test.go
+++ b/goagen/codegen/validation_test.go
@@ -62,9 +62,9 @@ var _ = Describe("validation code generation", func() {
 			Context("of min value 0", func() {
 				BeforeEach(func() {
 					attType = design.Integer
-					min := 0.0
+					min := 0
 					validation = &dslengine.ValidationDefinition{
-						Minimum: &min,
+						Minimum: min,
 					}
 				})
 
@@ -76,9 +76,9 @@ var _ = Describe("validation code generation", func() {
 			Context("of max value math.MaxInt64", func() {
 				BeforeEach(func() {
 					attType = design.Integer
-					max := float64(math.MaxInt64)
+					max := math.MaxInt64
 					validation = &dslengine.ValidationDefinition{
-						Maximum: &max,
+						Maximum: max,
 					}
 				})
 
@@ -90,9 +90,9 @@ var _ = Describe("validation code generation", func() {
 			Context("of min value math.MinInt64", func() {
 				BeforeEach(func() {
 					attType = design.Integer
-					min := float64(math.MinInt64)
+					min := math.MinInt64
 					validation = &dslengine.ValidationDefinition{
-						Minimum: &min,
+						Minimum: min,
 					}
 				})
 

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -15,38 +15,38 @@ type (
 	// JSONSchema represents an instance of a JSON schema.
 	// See http://json-schema.org/documentation.html
 	JSONSchema struct {
-		Schema string `json:"$schema,omitempty"`
+		Schema string `json:"$schema,omitempty" yaml:"$schema,omitempty"`
 		// Core schema
-		ID           string                 `json:"id,omitempty"`
-		Title        string                 `json:"title,omitempty"`
-		Type         JSONType               `json:"type,omitempty"`
-		Items        *JSONSchema            `json:"items,omitempty"`
-		Properties   map[string]*JSONSchema `json:"properties,omitempty"`
-		Definitions  map[string]*JSONSchema `json:"definitions,omitempty"`
-		Description  string                 `json:"description,omitempty"`
-		DefaultValue interface{}            `json:"default,omitempty"`
-		Example      interface{}            `json:"example,omitempty"`
+		ID           string                 `json:"id,omitempty" yaml:"id,omitempty"`
+		Title        string                 `json:"title,omitempty" yaml:"title,omitempty"`
+		Type         JSONType               `json:"type,omitempty" yaml:"type,omitempty"`
+		Items        *JSONSchema            `json:"items,omitempty" yaml:"items,omitempty"`
+		Properties   map[string]*JSONSchema `json:"properties,omitempty" yaml:"properties,omitempty"`
+		Definitions  map[string]*JSONSchema `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+		Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+		DefaultValue interface{}            `json:"default,omitempty" yaml:"default,omitempty"`
+		Example      interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
 
 		// Hyper schema
-		Media     *JSONMedia  `json:"media,omitempty"`
-		ReadOnly  bool        `json:"readOnly,omitempty"`
-		PathStart string      `json:"pathStart,omitempty"`
-		Links     []*JSONLink `json:"links,omitempty"`
-		Ref       string      `json:"$ref,omitempty"`
+		Media     *JSONMedia  `json:"media,omitempty" yaml:"media,omitempty"`
+		ReadOnly  bool        `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+		PathStart string      `json:"pathStart,omitempty" yaml:"pathStart,omitempty"`
+		Links     []*JSONLink `json:"links,omitempty" yaml:"links,omitempty"`
+		Ref       string      `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
 		// Validation
-		Enum                 []interface{} `json:"enum,omitempty"`
-		Format               string        `json:"format,omitempty"`
-		Pattern              string        `json:"pattern,omitempty"`
-		Minimum              *float64      `json:"minimum,omitempty"`
-		Maximum              *float64      `json:"maximum,omitempty"`
-		MinLength            *int          `json:"minLength,omitempty"`
-		MaxLength            *int          `json:"maxLength,omitempty"`
-		Required             []string      `json:"required,omitempty"`
-		AdditionalProperties bool          `json:"additionalProperties,omitempty"`
+		Enum                 []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+		Format               string        `json:"format,omitempty" yaml:"format,omitempty"`
+		Pattern              string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		Minimum              interface{}   `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		Maximum              interface{}   `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		MinLength            *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		MaxLength            *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		Required             []string      `json:"required,omitempty" yaml:"required,omitempty"`
+		AdditionalProperties bool          `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
 
 		// Union
-		AnyOf []*JSONSchema `json:"anyOf,omitempty"`
+		AnyOf []*JSONSchema `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
 	}
 
 	// JSONType is the JSON type enum.
@@ -54,21 +54,21 @@ type (
 
 	// JSONMedia represents a "media" field in a JSON hyper schema.
 	JSONMedia struct {
-		BinaryEncoding string `json:"binaryEncoding,omitempty"`
-		Type           string `json:"type,omitempty"`
+		BinaryEncoding string `json:"binaryEncoding,omitempty" yaml:"binaryEncoding,omitempty"`
+		Type           string `json:"type,omitempty" yaml:"type,omitempty"`
 	}
 
 	// JSONLink represents a "link" field in a JSON hyper schema.
 	JSONLink struct {
-		Title        string      `json:"title,omitempty"`
-		Description  string      `json:"description,omitempty"`
-		Rel          string      `json:"rel,omitempty"`
-		Href         string      `json:"href,omitempty"`
-		Method       string      `json:"method,omitempty"`
-		Schema       *JSONSchema `json:"schema,omitempty"`
-		TargetSchema *JSONSchema `json:"targetSchema,omitempty"`
-		MediaType    string      `json:"mediaType,omitempty"`
-		EncType      string      `json:"encType,omitempty"`
+		Title        string      `json:"title,omitempty" yaml:"title,omitempty"`
+		Description  string      `json:"description,omitempty" yaml:"description,omitempty"`
+		Rel          string      `json:"rel,omitempty" yaml:"rel,omitempty"`
+		Href         string      `json:"href,omitempty" yaml:"href,omitempty"`
+		Method       string      `json:"method,omitempty" yaml:"method,omitempty"`
+		Schema       *JSONSchema `json:"schema,omitempty" yaml:"schema,omitempty"`
+		TargetSchema *JSONSchema `json:"targetSchema,omitempty" yaml:"targetSchema,omitempty"`
+		MediaType    string      `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
+		EncType      string      `json:"encType,omitempty" yaml:"encType,omitempty"`
 	}
 )
 

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -341,12 +341,42 @@ func (s *JSONSchema) createMergeItems(other *JSONSchema) mergeItems {
 		{
 			a: s.Minimum, b: other.Minimum,
 			needed: (s.Minimum == nil && s.Minimum != nil) ||
-				(s.Minimum != nil && other.Minimum != nil && *s.Minimum > *other.Minimum),
+				(s.Minimum != nil && other.Minimum != nil && func() bool {
+					x := reflect.ValueOf(s.Minimum)
+					y := reflect.ValueOf(other.Minimum)
+					if x.Kind() != y.Kind() {
+						panic(fmt.Sprintf("non comparable types, %v(%[1]T) <> %v(%[2]T)", x, y))
+					}
+					switch x.Kind() {
+					case reflect.Int:
+						return x.Int() > y.Int()
+					case reflect.Float64:
+						return x.Float() > y.Float()
+					default:
+						panic(fmt.Sprintf("unknown type, %v(%[1]T)", x))
+					}
+					return false
+				}()),
 		},
 		{
 			a: s.Maximum, b: other.Maximum,
 			needed: (s.Maximum == nil && other.Maximum != nil) ||
-				(s.Maximum != nil && other.Maximum != nil && *s.Maximum < *other.Maximum),
+				(s.Maximum != nil && other.Maximum != nil && func() bool {
+					x := reflect.ValueOf(s.Maximum)
+					y := reflect.ValueOf(other.Maximum)
+					if x.Kind() != y.Kind() {
+						panic(fmt.Sprintf("non comparable types, %v(%[1]T) <> %v(%[2]T)", x, y))
+					}
+					switch x.Kind() {
+					case reflect.Int:
+						return x.Int() < y.Int()
+					case reflect.Float64:
+						return x.Float() < y.Float()
+					default:
+						panic(fmt.Sprintf("unknown type, %v(%[1]T)", x))
+					}
+					return false
+				}()),
 		},
 		{
 			a: s.MinLength, b: other.MinLength,

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -98,12 +98,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 	g.genfiles = append(g.genfiles, swaggerFile)
 
 	// YAML
-	var yamlSource interface{}
-	if err = json.Unmarshal(rawJSON, &yamlSource); err != nil {
-		return nil, err
-	}
-
-	rawYAML, err := yaml.Marshal(yamlSource)
+	rawYAML, err := yaml.Marshal(s)
 	if err != nil {
 		return nil, err
 	}

--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -16,192 +16,192 @@ type (
 	// Swagger represents an instance of a swagger object.
 	// See https://swagger.io/specification/
 	Swagger struct {
-		Swagger             string                           `json:"swagger,omitempty"`
-		Info                *Info                            `json:"info,omitempty"`
-		Host                string                           `json:"host,omitempty"`
-		BasePath            string                           `json:"basePath,omitempty"`
-		Schemes             []string                         `json:"schemes,omitempty"`
-		Consumes            []string                         `json:"consumes,omitempty"`
-		Produces            []string                         `json:"produces,omitempty"`
-		Paths               map[string]interface{}           `json:"paths"`
-		Definitions         map[string]*genschema.JSONSchema `json:"definitions,omitempty"`
-		Parameters          map[string]*Parameter            `json:"parameters,omitempty"`
-		Responses           map[string]*Response             `json:"responses,omitempty"`
-		SecurityDefinitions map[string]*SecurityDefinition   `json:"securityDefinitions,omitempty"`
-		Tags                []*Tag                           `json:"tags,omitempty"`
-		ExternalDocs        *ExternalDocs                    `json:"externalDocs,omitempty"`
+		Swagger             string                           `json:"swagger,omitempty" yaml:"swagger,omitempty"`
+		Info                *Info                            `json:"info,omitempty" yaml:"info,omitempty"`
+		Host                string                           `json:"host,omitempty" yaml:"host,omitempty"`
+		BasePath            string                           `json:"basePath,omitempty" yaml:"basePath,omitempty"`
+		Schemes             []string                         `json:"schemes,omitempty" yaml:"schemes,omitempty"`
+		Consumes            []string                         `json:"consumes,omitempty" yaml:"consumes,omitempty"`
+		Produces            []string                         `json:"produces,omitempty" yaml:"produces,omitempty"`
+		Paths               map[string]interface{}           `json:"paths" yaml:"paths"`
+		Definitions         map[string]*genschema.JSONSchema `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+		Parameters          map[string]*Parameter            `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		Responses           map[string]*Response             `json:"responses,omitempty" yaml:"responses,omitempty"`
+		SecurityDefinitions map[string]*SecurityDefinition   `json:"securityDefinitions,omitempty" yaml:"securityDefinitions,omitempty"`
+		Tags                []*Tag                           `json:"tags,omitempty" yaml:"tags,omitempty"`
+		ExternalDocs        *ExternalDocs                    `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 	}
 
 	// Info provides metadata about the API. The metadata can be used by the clients if needed,
 	// and can be presented in the Swagger-UI for convenience.
 	Info struct {
-		Title          string                    `json:"title,omitempty"`
-		Description    string                    `json:"description,omitempty"`
-		TermsOfService string                    `json:"termsOfService,omitempty"`
-		Contact        *design.ContactDefinition `json:"contact,omitempty"`
-		License        *design.LicenseDefinition `json:"license,omitempty"`
-		Version        string                    `json:"version"`
-		Extensions     map[string]interface{}    `json:"-"`
+		Title          string                    `json:"title,omitempty" yaml:"title,omitempty"`
+		Description    string                    `json:"description,omitempty" yaml:"description,omitempty"`
+		TermsOfService string                    `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+		Contact        *design.ContactDefinition `json:"contact,omitempty" yaml:"contact,omitempty"`
+		License        *design.LicenseDefinition `json:"license,omitempty" yaml:"license,omitempty"`
+		Version        string                    `json:"version" yaml:"version"`
+		Extensions     map[string]interface{}    `json:"-" yaml:"-"`
 	}
 
 	// Path holds the relative paths to the individual endpoints.
 	Path struct {
 		// Ref allows for an external definition of this path item.
-		Ref string `json:"$ref,omitempty"`
+		Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 		// Get defines a GET operation on this path.
-		Get *Operation `json:"get,omitempty"`
+		Get *Operation `json:"get,omitempty" yaml:"get,omitempty"`
 		// Put defines a PUT operation on this path.
-		Put *Operation `json:"put,omitempty"`
+		Put *Operation `json:"put,omitempty" yaml:"put,omitempty"`
 		// Post defines a POST operation on this path.
-		Post *Operation `json:"post,omitempty"`
+		Post *Operation `json:"post,omitempty" yaml:"post,omitempty"`
 		// Delete defines a DELETE operation on this path.
-		Delete *Operation `json:"delete,omitempty"`
+		Delete *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
 		// Options defines a OPTIONS operation on this path.
-		Options *Operation `json:"options,omitempty"`
+		Options *Operation `json:"options,omitempty" yaml:"options,omitempty"`
 		// Head defines a HEAD operation on this path.
-		Head *Operation `json:"head,omitempty"`
+		Head *Operation `json:"head,omitempty" yaml:"head,omitempty"`
 		// Patch defines a PATCH operation on this path.
-		Patch *Operation `json:"patch,omitempty"`
+		Patch *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
 		// Parameters is the list of parameters that are applicable for all the operations
 		// described under this path.
-		Parameters []*Parameter `json:"parameters,omitempty"`
+		Parameters []*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// Operation describes a single API operation on a path.
 	Operation struct {
 		// Tags is a list of tags for API documentation control. Tags can be used for
 		// logical grouping of operations by resources or any other qualifier.
-		Tags []string `json:"tags,omitempty"`
+		Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 		// Summary is a short summary of what the operation does. For maximum readability
 		// in the swagger-ui, this field should be less than 120 characters.
-		Summary string `json:"summary,omitempty"`
+		Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
 		// Description is a verbose explanation of the operation behavior.
 		// GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// ExternalDocs points to additional external documentation for this operation.
-		ExternalDocs *ExternalDocs `json:"externalDocs,omitempty"`
+		ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 		// OperationID is a unique string used to identify the operation.
-		OperationID string `json:"operationId,omitempty"`
+		OperationID string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 		// Consumes is a list of MIME types the operation can consume.
-		Consumes []string `json:"consumes,omitempty"`
+		Consumes []string `json:"consumes,omitempty" yaml:"consumes,omitempty"`
 		// Produces is a list of MIME types the operation can produce.
-		Produces []string `json:"produces,omitempty"`
+		Produces []string `json:"produces,omitempty" yaml:"produces,omitempty"`
 		// Parameters is a list of parameters that are applicable for this operation.
-		Parameters []*Parameter `json:"parameters,omitempty"`
+		Parameters []*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 		// Responses is the list of possible responses as they are returned from executing
 		// this operation.
-		Responses map[string]*Response `json:"responses,omitempty"`
+		Responses map[string]*Response `json:"responses,omitempty" yaml:"responses,omitempty"`
 		// Schemes is the transfer protocol for the operation.
-		Schemes []string `json:"schemes,omitempty"`
+		Schemes []string `json:"schemes,omitempty" yaml:"schemes,omitempty"`
 		// Deprecated declares this operation to be deprecated.
-		Deprecated bool `json:"deprecated,omitempty"`
+		Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 		// Secury is a declaration of which security schemes are applied for this operation.
-		Security []map[string][]string `json:"security,omitempty"`
+		Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// Parameter describes a single operation parameter.
 	Parameter struct {
 		// Name of the parameter. Parameter names are case sensitive.
-		Name string `json:"name"`
+		Name string `json:"name" yaml:"name"`
 		// In is the location of the parameter.
 		// Possible values are "query", "header", "path", "formData" or "body".
-		In string `json:"in"`
+		In string `json:"in" yaml:"in"`
 		// Description is`a brief description of the parameter.
 		// GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// Required determines whether this parameter is mandatory.
-		Required bool `json:"required"`
+		Required bool `json:"required" yaml:"required"`
 		// Schema defining the type used for the body parameter, only if "in" is body
-		Schema *genschema.JSONSchema `json:"schema,omitempty"`
+		Schema *genschema.JSONSchema `json:"schema,omitempty" yaml:"schema,omitempty"`
 
 		// properties below only apply if "in" is not body
 
 		//  Type of the parameter. Since the parameter is not located at the request body,
 		// it is limited to simple types (that is, not an object).
-		Type string `json:"type,omitempty"`
+		Type string `json:"type,omitempty" yaml:"type,omitempty"`
 		// Format is the extending format for the previously mentioned type.
-		Format string `json:"format,omitempty"`
+		Format string `json:"format,omitempty" yaml:"format,omitempty"`
 		// AllowEmptyValue sets the ability to pass empty-valued parameters.
 		// This is valid only for either query or formData parameters and allows you to
 		// send a parameter with a name only or an empty value. Default value is false.
-		AllowEmptyValue bool `json:"allowEmptyValue,omitempty"`
+		AllowEmptyValue bool `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 		// Items describes the type of items in the array if type is "array".
-		Items *Items `json:"items,omitempty"`
+		Items *Items `json:"items,omitempty" yaml:"items,omitempty"`
 		// CollectionFormat determines the format of the array if type array is used.
 		// Possible values are csv, ssv, tsv, pipes and multi.
-		CollectionFormat string `json:"collectionFormat,omitempty"`
+		CollectionFormat string `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty"`
+		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          interface{}   `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          interface{}   `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// Response describes an operation response.
 	Response struct {
 		// Description of the response. GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// Schema is a definition of the response structure. It can be a primitive,
 		// an array or an object. If this field does not exist, it means no content is
 		// returned as part of the response. As an extension to the Schema Object, its root
 		// type value may also be "file".
-		Schema *genschema.JSONSchema `json:"schema,omitempty"`
+		Schema *genschema.JSONSchema `json:"schema,omitempty" yaml:"schema,omitempty"`
 		// Headers is a list of headers that are sent with the response.
-		Headers map[string]*Header `json:"headers,omitempty"`
+		Headers map[string]*Header `json:"headers,omitempty" yaml:"headers,omitempty"`
 		// Ref references a global API response.
 		// This field is exclusive with the other fields of Response.
-		Ref string `json:"$ref,omitempty"`
+		Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// Header represents a header parameter.
 	Header struct {
 		// Description is`a brief description of the parameter.
 		// GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		//  Type of the header. it is limited to simple types (that is, not an object).
-		Type string `json:"type,omitempty"`
+		Type string `json:"type,omitempty" yaml:"type,omitempty"`
 		// Format is the extending format for the previously mentioned type.
-		Format string `json:"format,omitempty"`
+		Format string `json:"format,omitempty" yaml:"format,omitempty"`
 		// Items describes the type of items in the array if type is "array".
-		Items *Items `json:"items,omitempty"`
+		Items *Items `json:"items,omitempty" yaml:"items,omitempty"`
 		// CollectionFormat determines the format of the array if type array is used.
 		// Possible values are csv, ssv, tsv, pipes and multi.
-		CollectionFormat string `json:"collectionFormat,omitempty"`
+		CollectionFormat string `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty"`
+		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          interface{}   `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          interface{}   `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	}
 
 	// SecurityDefinition allows the definition of a security scheme that can be used by the
@@ -210,84 +210,84 @@ type (
 	// access code).
 	SecurityDefinition struct {
 		// Type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-		Type string `json:"type"`
+		Type string `json:"type" yaml:"type"`
 		// Description for security scheme
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// Name of the header or query parameter to be used when type is "apiKey".
-		Name string `json:"name,omitempty"`
+		Name string `json:"name,omitempty" yaml:"name,omitempty"`
 		// In is the location of the API key when type is "apiKey".
 		// Valid values are "query" or "header".
-		In string `json:"in,omitempty"`
+		In string `json:"in,omitempty" yaml:"in,omitempty"`
 		// Flow is the flow used by the OAuth2 security scheme when type is "oauth2"
 		// Valid values are "implicit", "password", "application" or "accessCode".
-		Flow string `json:"flow,omitempty"`
+		Flow string `json:"flow,omitempty" yaml:"flow,omitempty"`
 		// The oauth2 authorization URL to be used for this flow.
-		AuthorizationURL string `json:"authorizationUrl,omitempty"`
+		AuthorizationURL string `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 		// TokenURL  is the token URL to be used for this flow.
-		TokenURL string `json:"tokenUrl,omitempty"`
+		TokenURL string `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
 		// Scopes list the  available scopes for the OAuth2 security scheme.
-		Scopes map[string]string `json:"scopes,omitempty"`
+		Scopes map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// Scope corresponds to an available scope for an OAuth2 security scheme.
 	Scope struct {
 		// Description for scope
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	}
 
 	// ExternalDocs allows referencing an external resource for extended documentation.
 	ExternalDocs struct {
 		// Description is a short description of the target documentation.
 		// GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// URL for the target documentation.
-		URL string `json:"url"`
+		URL string `json:"url" yaml:"url"`
 	}
 
 	// Items is a limited subset of JSON-Schema's items object. It is used by parameter
 	// definitions that are not located in "body".
 	Items struct {
 		//  Type of the items. it is limited to simple types (that is, not an object).
-		Type string `json:"type,omitempty"`
+		Type string `json:"type,omitempty" yaml:"type,omitempty"`
 		// Format is the extending format for the previously mentioned type.
-		Format string `json:"format,omitempty"`
+		Format string `json:"format,omitempty" yaml:"format,omitempty"`
 		// Items describes the type of items in the array if type is "array".
-		Items *Items `json:"items,omitempty"`
+		Items *Items `json:"items,omitempty" yaml:"items,omitempty"`
 		// CollectionFormat determines the format of the array if type array is used.
 		// Possible values are csv, ssv, tsv, pipes and multi.
-		CollectionFormat string `json:"collectionFormat,omitempty"`
+		CollectionFormat string `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty"`
+		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          interface{}   `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          interface{}   `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	}
 
 	// Tag allows adding meta data to a single tag that is used by the Operation Object. It is
 	// not mandatory to have a Tag Object per tag used there.
 	Tag struct {
 		// Name of the tag.
-		Name string `json:"name,omitempty"`
+		Name string `json:"name,omitempty" yaml:"name,omitempty"`
 		// Description is a short description of the tag.
 		// GFM syntax can be used for rich text representation.
-		Description string `json:"description,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 		// ExternalDocs is additional external documentation for this tag.
-		ExternalDocs *ExternalDocs `json:"externalDocs,omitempty"`
+		ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-"`
+		Extensions map[string]interface{} `json:"-" yaml:"-"`
 	}
 
 	// These types are used in marshalJSON() to avoid recursive call of json.Marshal().

--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -1101,7 +1101,7 @@ func initPatternValidation(def interface{}, pattern string) {
 	}
 }
 
-func initMinimumValidation(def interface{}, min *float64) {
+func initMinimumValidation(def interface{}, min interface{}) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Minimum = min
@@ -1115,7 +1115,7 @@ func initMinimumValidation(def interface{}, min *float64) {
 	}
 }
 
-func initMaximumValidation(def interface{}, max *float64) {
+func initMaximumValidation(def interface{}, max interface{}) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Maximum = max

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -146,7 +146,7 @@ var _ = Describe("New", func() {
 				boolParam   = "boolParam"
 				queryParam  = "queryParam"
 				description = "description"
-				intMin      = 1.0
+				intMin      = 1
 				floatMax    = 2.4
 				enum1       = "enum1"
 				enum2       = "enum2"
@@ -192,13 +192,13 @@ var _ = Describe("New", func() {
 				Ω(swagger.Parameters[intParam].In).Should(Equal("path"))
 				Ω(swagger.Parameters[intParam].Required).Should(BeTrue())
 				Ω(swagger.Parameters[intParam].Type).Should(Equal("integer"))
-				Ω(*swagger.Parameters[intParam].Minimum).Should(Equal(intMin))
+				Ω(swagger.Parameters[intParam].Minimum).Should(Equal(intMin))
 				Ω(swagger.Parameters[numParam]).ShouldNot(BeNil())
 				Ω(swagger.Parameters[numParam].Name).Should(Equal(numParam))
 				Ω(swagger.Parameters[numParam].In).Should(Equal("path"))
 				Ω(swagger.Parameters[numParam].Required).Should(BeTrue())
 				Ω(swagger.Parameters[numParam].Type).Should(Equal("number"))
-				Ω(*swagger.Parameters[numParam].Maximum).Should(Equal(floatMax))
+				Ω(swagger.Parameters[numParam].Maximum).Should(Equal(floatMax))
 				Ω(swagger.Parameters[boolParam]).ShouldNot(BeNil())
 				Ω(swagger.Parameters[boolParam].Name).Should(Equal(boolParam))
 				Ω(swagger.Parameters[boolParam].In).Should(Equal("path"))
@@ -286,7 +286,7 @@ var _ = Describe("New", func() {
 				intParam = "intParam"
 				numParam = "numParam"
 				strParam = "strParam"
-				intMin   = 0.0
+				intMin   = 0
 				floatMax = 0.0
 			)
 
@@ -412,8 +412,8 @@ var _ = Describe("New", func() {
 			var (
 				minLength1  = 1
 				maxLength10 = 10
-				minimum_2   = -2.0
-				maximum2    = 2.0
+				minimum_2   = -2
+				maximum2    = 2
 				minItems1   = 1
 				maxItems5   = 5
 			)
@@ -560,7 +560,7 @@ var _ = Describe("New", func() {
 					Items: &genswagger.Items{Type: "string"}, MinItems: &minItems1, MaxItems: &maxItems5}))
 				Ω(ps[5]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalBoolWithDefault", Type: "boolean",
 					Description: "defaults true", Default: true}))
-				Ω(ps[6]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalInt", Type: "integer", Minimum: &minimum_2, Maximum: &maximum2}))
+				Ω(ps[6]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalInt", Type: "integer", Minimum: minimum_2, Maximum: maximum2}))
 				Ω(ps[7]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalRegex", Type: "string",
 					Pattern: `[a-z]\d+`, MinLength: &minLength1, MaxLength: &maxLength10}))
 				Ω(ps[8]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalResourceHeaderWithEnum", Type: "string",


### PR DESCRIPTION
goa で Minimum/Maximum を設定すると，swagger.yaml では設定した値が浮動小数点として出力されています．これは，goa の内部で Minimum/Maximum の値が float64 で表現されているためです．

また yaml ファイルは json ファイルを読み込み直して生成されるので，ここでも型情報が落ちる可能性があります．

そんなわけで下記のように変更してみました．

* Minimum/Maximum の情報を interface{} で保持
* Attribute の型に従う値しか認めない (Integer なのに Maximum(99.9) はだめ)
* swagger.yaml を直接出力

もしお時間あればレビューしていただけるとありがたいです :bow: #

内部の値を int/float64 で持つようにしてるんですが，int64 にしておいたほうがいいのかな？